### PR TITLE
Make command compatible to other shells especially zsh

### DIFF
--- a/docs/how-to/contribute.rst
+++ b/docs/how-to/contribute.rst
@@ -204,7 +204,7 @@ ask coverage to generate a report of the data that was gathered:
 
       (venv) $ pip install coverage
       (venv) $ coverage run setup.py test
-      (venv) $ coverage report -m --include=toga/*
+      (venv) $ coverage report -m --include="toga/*"
       Name                                 Stmts   Miss  Cover   Missing
       ------------------------------------------------------------------
       toga/__init__.py                        29      0   100%
@@ -220,7 +220,7 @@ ask coverage to generate a report of the data that was gathered:
 
       (venv) $ pip install coverage
       (venv) $ coverage run setup.py test
-      (venv) $ coverage report -m --include=toga/*
+      (venv) $ coverage report -m --include="toga/*"
       Name                                 Stmts   Miss  Cover   Missing
       ------------------------------------------------------------------
       toga/__init__.py                        29      0   100%
@@ -277,7 +277,7 @@ expect to see something like:
       Ran 101 tests in 0.343s
 
       OK (skipped=1)
-      (venv) $ coverage report -m --include=toga/*
+      (venv) $ coverage report -m --include="toga/*"
       Name                                 Stmts   Miss  Cover   Missing
       ------------------------------------------------------------------
       toga/__init__.py                        29      0   100%
@@ -298,7 +298,7 @@ expect to see something like:
       Ran 101 tests in 0.343s
 
       OK (skipped=1)
-      (venv) $ coverage report -m --include=toga/*
+      (venv) $ coverage report -m --include="toga/*"
       Name                                 Stmts   Miss  Cover   Missing
       ------------------------------------------------------------------
       toga/__init__.py                        29      0   100%


### PR DESCRIPTION
Small fix to make coverage's `--include` flag to do pattern matching rather than zsh globbing `*`.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
